### PR TITLE
Version 3.2.0 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [3.2.0] 2021-12-31
+
+### CHANGED
+
+- Bump core compatible version to 0.9.
 ## [3.1.0] 2021-06-19
 
 ### ADDED

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## [3.2.0] 2021-12-31
 
+### ADDED
+
+- Added option to recover hit dice before rolling.
+
 ### CHANGED
 
 - Bump core compatible version to 0.9.
+- Auto-roll hit dice when recovery fraction is set to "Full".
+
 ## [3.1.0] 2021-06-19
 
 ### ADDED

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### CHANGED
 
+- Maintainer is now @a-ws-m.
 - Bump core compatible version to 0.9.
 - Auto-roll hit dice when recovery fraction is set to "Full".
 

--- a/lr-hd-healing.js
+++ b/lr-hd-healing.js
@@ -21,7 +21,7 @@ Hooks.on("init", () => {
 
     game.settings.register("long-rest-hd-healing", "recovery-mult", {
         name: "Hit Dice Recovery Fraction",
-        hint: "The fraction of hit dice to recover on a long rest. If this is set to \"Full\", hit dice will be autorolled.",
+        hint: "The fraction of hit dice to recover on a long rest. If this is set to \"Full\", hit dice will be auto-rolled.",
         scope: "world",
         config: true,
         type: String,

--- a/lr-hd-healing.js
+++ b/lr-hd-healing.js
@@ -131,7 +131,7 @@ Hooks.on("init", () => {
 function patch_newLongRest() {
     libWrapper.register(
         "long-rest-hd-healing",
-        "CONFIG.Actor.entityClass.prototype.longRest",
+        "CONFIG.Actor.documentClass.prototype.longRest",
         async function patchedLongRest(...args) {
             let { chat=true, dialog=true, newDay=true } = args[0] ?? {};
 
@@ -169,7 +169,7 @@ function patch_newLongRest() {
 function patch_getRestHitPointRecovery() {
     libWrapper.register(
         "long-rest-hd-healing",
-        "CONFIG.Actor.entityClass.prototype._getRestHitPointRecovery",
+        "CONFIG.Actor.documentClass.prototype._getRestHitPointRecovery",
         function patched_getRestHitPointRecovery(wrapped, ...args) {
             const currentHP = this.data.data.attributes.hp.value;
             const result = wrapped(...args);
@@ -186,7 +186,7 @@ function patch_getRestHitPointRecovery() {
 function patch_getRestHitDiceRecovery() {
     libWrapper.register(
         "long-rest-hd-healing",
-        "CONFIG.Actor.entityClass.prototype._getRestHitDiceRecovery",
+        "CONFIG.Actor.documentClass.prototype._getRestHitDiceRecovery",
         function patched_getRestHitDiceRecovery(wrapped, ...args) {
             const { maxHitDice=undefined } = args[0] ?? {};
 
@@ -209,7 +209,7 @@ function patch_getRestHitDiceRecovery() {
 function patch_getRestResourceRecovery() {
     libWrapper.register(
         "long-rest-hd-healing",
-        "CONFIG.Actor.entityClass.prototype._getRestResourceRecovery",
+        "CONFIG.Actor.documentClass.prototype._getRestResourceRecovery",
         function patched_getRestResourceRecovery(...args) {
             const { recoverShortRestResources=true, recoverLongRestResources=true } = args[0] ?? {};
 
@@ -238,7 +238,7 @@ function patch_getRestResourceRecovery() {
 function patch_getRestSpellRecovery() {
     libWrapper.register(
         "long-rest-hd-healing",
-        "CONFIG.Actor.entityClass.prototype._getRestSpellRecovery",
+        "CONFIG.Actor.documentClass.prototype._getRestSpellRecovery",
         function patched_getRestSpellRecovery(wrapped, ...args) {
             const { recoverPact=true, recoverSpells=true } = args[0] ?? {};
 
@@ -267,7 +267,7 @@ function patch_getRestSpellRecovery() {
 function patch_getRestItemUsesRecovery() {
     libWrapper.register(
         "long-rest-hd-healing",
-        "CONFIG.Actor.entityClass.prototype._getRestItemUsesRecovery",
+        "CONFIG.Actor.documentClass.prototype._getRestItemUsesRecovery",
         function patched_getRestItemUsesRecovery(wrapped, ...args) {
             const { recoverShortRestUses=true, recoverLongRestUses=true, recoverDailyUses=true } = args[0] ?? {};
 

--- a/module.json
+++ b/module.json
@@ -3,17 +3,16 @@
   "title": "Long Rest Hit Die Healing for D&D5e",
   "description": "Adds the \"Slow Natural Healing\" rules to the dnd5e system. Rather than healing to full hit points, actors now have the option to spend hit dice on a long rest.",
   "system": "dnd5e",
-  "version": "3.1.0",
-  "author": "Cole Schultz (cole#9640)",
+  "version": "3.2.0",
+  "authors": ["Cole Schultz", "Alex Moriarty"],
   "esmodules": [
     "lr-hd-healing.js"
   ],
-  "minimumCoreVersion": "0.8.5",
-  "compatibleCoreVersion": "0.8.7",
-  "url": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e",
-  "manifest": "https://raw.githubusercontent.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/master/module.json",
-  "download": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/archive/3.1.0.zip",
-  "license": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/blob/3.1.0/LICENSE",
-  "readme": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/blob/3.1.0/README.md",
-  "changelog": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/blob/3.1.0/CHANGELOG.md"
+  "minimumCoreVersion": "0.9",
+  "url": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e",
+  "manifest": "https://raw.githubusercontent.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/master/module.json",
+  "download": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/archive/3.2.0.zip",
+  "license": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/blob/3.2.0/LICENSE",
+  "readme": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/blob/3.2.0/README.md",
+  "changelog": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/blob/3.2.0/CHANGELOG.md"
 }

--- a/module.json
+++ b/module.json
@@ -2,9 +2,7 @@
   "name": "long-rest-hd-healing",
   "title": "Long Rest Hit Die Healing for D&D5e",
   "description": "Adds the \"Slow Natural Healing\" rules to the dnd5e system. Rather than healing to full hit points, actors now have the option to spend hit dice on a long rest.",
-  "systems": [
-    "dnd5e"
-  ],
+  "system": "dnd5e",
   "version": "3.1.0",
   "author": "Cole Schultz (cole#9640)",
   "esmodules": [

--- a/module.json
+++ b/module.json
@@ -9,10 +9,10 @@
     "lr-hd-healing.js"
   ],
   "minimumCoreVersion": "0.9",
-  "url": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e",
-  "manifest": "https://raw.githubusercontent.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/master/module.json",
-  "download": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/archive/3.2.0.zip",
-  "license": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/blob/3.2.0/LICENSE",
-  "readme": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/blob/3.2.0/README.md",
-  "changelog": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/blob/3.2.0/CHANGELOG.md"
+  "url": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e",
+  "manifest": "https://raw.githubusercontent.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/master/module.json",
+  "download": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/archive/3.2.0.zip",
+  "license": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/blob/3.2.0/LICENSE",
+  "readme": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/blob/3.2.0/README.md",
+  "changelog": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/blob/3.2.0/CHANGELOG.md"
 }

--- a/module.json
+++ b/module.json
@@ -9,10 +9,10 @@
     "lr-hd-healing.js"
   ],
   "minimumCoreVersion": "0.9",
-  "url": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e",
-  "manifest": "https://raw.githubusercontent.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/master/module.json",
-  "download": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/archive/3.2.0.zip",
-  "license": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/blob/3.2.0/LICENSE",
-  "readme": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/blob/3.2.0/README.md",
-  "changelog": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/blob/3.2.0/CHANGELOG.md"
+  "url": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e",
+  "manifest": "https://raw.githubusercontent.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/master/module.json",
+  "download": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/archive/3.2.0.zip",
+  "license": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/blob/3.2.0/LICENSE",
+  "readme": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/blob/3.2.0/README.md",
+  "changelog": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/blob/3.2.0/CHANGELOG.md"
 }

--- a/new-long-rest.js
+++ b/new-long-rest.js
@@ -20,27 +20,26 @@ export default class HDLongRestDialog extends ShortRestDialog {
     static async hdLongRestDialog({ actor } = {}) {
         return new Promise((resolve, reject) => {
             const dlg = new this(actor, {
-                title: "Long Rest",
+                title: game.i18n.localize("DND5E.LongRest"),
                 buttons: {
                     rest: {
                         icon: "<i class=\"fas fa-bed\"></i>",
                         label: "Rest",
                         callback: html => {
-                            let newDay = false;
-                            if (game.settings.get("dnd5e", "restVariant") === "normal") {
+                            let newDay = true;
+                            if (game.settings.get("dnd5e", "restVariant") !== "gritty") {
                                 newDay = html.find("input[name=\"newDay\"]")[0].checked;
-                            } else if (game.settings.get("dnd5e", "restVariant") === "gritty") {
-                                newDay = true;
                             }
                             resolve(newDay);
                         },
                     },
                     cancel: {
                         icon: "<i class=\"fas fa-times\"></i>",
-                        label: "Cancel",
+                        label: game.i18n.localize("Cancel"),
                         callback: reject,
                     },
                 },
+                default: "rest",
                 close: reject,
             });
             dlg.render(true);

--- a/new-long-rest.js
+++ b/new-long-rest.js
@@ -11,8 +11,11 @@ export default class HDLongRestDialog extends ShortRestDialog {
     getData() {
         const data = super.getData();
         const variant = game.settings.get("dnd5e", "restVariant");
+        const recoveryHDMultSetting = game.settings.get("long-rest-hd-healing", "recovery-mult");
         data.promptNewDay = variant !== "gritty";     // It's always a new day when resting 1 week
         data.newDay = variant === "normal";           // It's probably a new day when resting normally (8 hours)
+        // We'll autoroll if all hit dice are to be recovered.
+        if (recoveryHDMultSetting === "full") data.canRoll = false;
         return data;
     }
 


### PR DESCRIPTION
# Hi

I want to thank @schultzcole for their hard work in making this module! They've agreed to hand over the module maintenance to me and they've been in touch with the Foundry team; I should be able to access the developer dashboard and add the latest module release when that's done. In the meantime, you should be able to install the module using the manifest URL: https://raw.githubusercontent.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/master/module.json .

In this update:
* Foundry v0.9 compatibility
* Added support for recovering hit dice before rolling (thanks to @GambetTV and @misthero for the suggestion).
* Auto-roll all available hit dice (or, at least, enough to recover max HP) when the hit dice recovery fraction is set to "full" (thanks to @flamewave000 ; it's not exactly what you suggested, but it's basically the same).

This fork of the repository will host all future updates -- please submit issues (feature requests and bugs) [here](https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/issues) and feel free to discuss/ask questions on the [discussion page](https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/discussions).