### PR TITLE
Complete localization and fix auto-rolling

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "long-rest-hd-healing",
   "title": "Long Rest Hit Die Healing for D&D5e",
   "description": "Adds the \"Slow Natural Healing\" rules to the dnd5e system. Rather than healing to full hit points, actors now have the option to spend hit dice on a long rest.",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "authors": [
     { "name": "Cole Schultz" },
     { "name": "Alex Moriarty" },
@@ -14,7 +14,7 @@
   ],
   "compatibility": {
     "minimum": 10,
-    "verified": 10
+    "verified": 11
   },
   "relationships": {
     "systems": [
@@ -23,8 +23,8 @@
   },
   "url": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e",
   "manifest": "https://raw.githubusercontent.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/master/module.json",
-  "download": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/archive/3.3.1.zip",
-  "license": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/blob/3.3.1/LICENSE",
-  "readme": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/blob/3.3.1/README.md",
-  "changelog": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/blob/3.3.1/CHANGELOG.md"
+  "download": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/archive/3.3.2.zip",
+  "license": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/blob/3.3.2/LICENSE",
+  "readme": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/blob/3.3.2/README.md",
+  "changelog": "https://github.com/a-ws-m/FVTT-Long-Rest-HD-Healing-5e/blob/3.3.2/CHANGELOG.md"
 }

--- a/new-long-rest.js
+++ b/new-long-rest.js
@@ -25,7 +25,7 @@ export default class HDLongRestDialog extends dnd5e.applications.actor.ShortRest
                 buttons: {
                     rest: {
                         icon: "<i class=\"fas fa-bed\"></i>",
-                        label: "Rest",
+                        label: game.i18n.localize("DND5E.Rest"),
                         callback: html => {
                             let newDay = true;
                             if (game.settings.get("dnd5e", "restVariant") !== "gritty") {

--- a/templates/hd-long-rest.html
+++ b/templates/hd-long-rest.html
@@ -1,5 +1,5 @@
 <form id="short-rest-hd" class="dialog-content" onsubmit="event.preventDefault();">
-    <p>Take a long rest? On a long rest you will recover hit points, half your maximum hit dice, class resources, limited use item charges, and spell slots.</p>
+    <p>{{ localize "DND5E.LongRestHint" }}</p>
     <div class="form-group">
         <label>{{ localize "DND5E.ShortRestSelect" }}</label>
         <div class="form-fields">
@@ -21,9 +21,9 @@
 
     {{#if promptNewDay}}
     <div class="form-group">
-        <label>Is New Day?</label>
+        <label>{{ localize "DND5E.NewDay" }}</label>
         <input type="checkbox" name="newDay" {{checked newDay}}/>
-        <p class="hint">Recover limited use abilities which recharge "per day"?</p>
+        <p class="hint">{{ localize "DND5E.NewDayHint" }}</p>
     </div>
     {{/if}}
 


### PR DESCRIPTION
This adds @mhilbrunner's localisation and also fixes #3. There was also a tangential issue with the `hit dice recovery = full` configuration: I had hard-coded it to always roll hit dice before resting, regardless of the "recover hit dice before resting" option; this has also been fixed.